### PR TITLE
WIP: Make this work in a concurrent setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0.31"
 failure_derive = "0.1.2"
 failure = "0.1.2"
 serde_derive = "1.0.79"
+crossbeam-channel = "0.2.6"
 
 [dev-dependencies]
 proptest = "0.8.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ proptest = "0.8.7"
 assert_fs = "0.9.0"
 predicates = "0.9.0"
 output_derive = { version = "0.1", path = "output_derive" }
+rand = "0.5.5"

--- a/examples/concurrent.rs
+++ b/examples/concurrent.rs
@@ -1,0 +1,37 @@
+extern crate failure;
+extern crate output;
+extern crate rand;
+
+use output::{human, json};
+use rand::distributions::Distribution;
+use rand::distributions::Range;
+use rand::thread_rng;
+use std::thread;
+use std::time::Duration;
+
+fn main() -> Result<(), failure::Error> {
+    let out = output::new()
+        .add_target(json::file("target/foo.log")?)
+        .add_target(human::stdout()?);
+
+    let mut threads = vec![];
+    for i in 0..100 {
+        let mut out = out.clone();
+        let t = thread::spawn(move || {
+            let dur = Duration::from_millis({
+                let mut rng = thread_rng();
+                let range = Range::new(0u64, 1);
+                range.sample(&mut rng)
+            });
+            thread::sleep(dur);
+            out.print(&format!("thread {} says hello", i))
+        });
+        threads.push(t);
+    }
+
+    threads.into_iter().for_each(|t| {
+        t.join().unwrap().unwrap();
+    });
+
+    Ok(())
+}

--- a/output_derive/src/lib.rs
+++ b/output_derive/src/lib.rs
@@ -21,6 +21,7 @@
 //!     code: 42,
 //!     message: String::from("Derive works"),
 //! })?;
+//! # out.flush()?;
 //! # assert_eq!(test_target.to_string(), "code: 42\nmessage: Derive works\n\n");
 //! # Ok(()) }
 //! ```

--- a/output_derive/tests/structs.rs
+++ b/output_derive/tests/structs.rs
@@ -24,6 +24,7 @@ fn struct_with_named_fields_of_primitive_types() -> Result<(), output::Error> {
         name: String::from("info"),
         message: String::from("Derive works"),
     })?;
+    out.flush()?;
 
     assert_eq!(
         human.to_string(),
@@ -52,6 +53,7 @@ fn tuple_struct_of_primitive_types() -> Result<(), output::Error> {
         .add_target(json.target());
 
     out.print(&ErrorMessage(42, String::from("Derive works")))?;
+    out.flush()?;
 
     assert_eq!(human.to_string(), "(42, Derive works)\n");
 

--- a/output_derive/tests/structs.rs
+++ b/output_derive/tests/structs.rs
@@ -35,7 +35,7 @@ fn struct_with_named_fields_of_primitive_types() -> Result<(), output::Error> {
 
     assert_eq!(
         json.to_string(),
-        "{\"code\":42,\"name\":\"info\",\"message\":\"Derive works\"}\n\n"
+        "{\"code\":42,\"name\":\"info\",\"message\":\"Derive works\"}\n"
     );
 
     Ok(())
@@ -57,7 +57,7 @@ fn tuple_struct_of_primitive_types() -> Result<(), output::Error> {
 
     assert_eq!(human.to_string(), "(42, Derive works)\n");
 
-    assert_eq!(json.to_string(), "[42,\"Derive works\"]\n\n");
+    assert_eq!(json.to_string(), "[42,\"Derive works\"]\n");
 
     Ok(())
 }

--- a/src/components/span.rs
+++ b/src/components/span.rs
@@ -112,8 +112,12 @@ impl Render for Span {
     }
 
     fn render_json(&self, fmt: &mut json::Formatter) -> Result<(), Error> {
-        for item in &self.items {
-            item.render_json(fmt)?;
+        let len = self.items.len();
+        for i in 0..len {
+            self.items[i].render_json(fmt)?;
+            if i < len - 1 {
+                fmt.write_separator()?;
+            }
         }
         Ok(())
     }
@@ -138,7 +142,7 @@ mod test {
 
         let json = json::test();
         item.render_json(&mut json.formatter())?;
-        assert_eq!(json.to_string(), "\"one\"\n\"two\"\n\"three\"\n");
+        assert_eq!(json.to_string(), "\"one\"\n\"two\"\n\"three\"");
         Ok(())
     }
 

--- a/src/components/span.rs
+++ b/src/components/span.rs
@@ -1,4 +1,4 @@
-use termcolor::{ColorSpec, WriteColor};
+use termcolor::ColorSpec;
 use {human, json, Error, Render};
 
 /// Construct a new, empty span
@@ -96,7 +96,7 @@ impl Span {
 
 impl Render for Span {
     fn render_for_humans(&self, fmt: &mut human::Formatter) -> Result<(), Error> {
-        fmt.writer.set_color(
+        fmt.set_color(
             ColorSpec::new()
                 .set_fg(self.fg)
                 .set_bg(self.bg)
@@ -107,7 +107,7 @@ impl Render for Span {
         for item in &self.items {
             item.render_for_humans(fmt)?;
         }
-        fmt.writer.reset()?;
+        fmt.reset()?;
         Ok(())
     }
 
@@ -146,7 +146,10 @@ mod test {
     fn test_colored_output() -> Result<(), Error> {
         let test_target = human::test_with_color();
         let mut out = ::new().add_target(test_target.target());
+
         out.print(span().add_item("hello").fg("green")?.bg("blue")?)?;
+        out.flush()?;
+
         assert_eq!(
             test_target.to_string(),
             "\u{1b}[0m\u{1b}[32m\u{1b}[44mhello\u{1b}[0m\n"
@@ -158,7 +161,10 @@ mod test {
     fn test_bold_output() -> Result<(), Error> {
         let test_target = human::test_with_color();
         let mut out = ::new().add_target(test_target.target());
+
         out.print(span().add_item("hello").bold(true)?)?;
+        out.flush()?;
+
         assert_eq!(
             test_target.to_string(),
             "\u{1b}[0m\u{1b}[1mhello\u{1b}[0m\n"
@@ -170,7 +176,10 @@ mod test {
     fn test_intense_output() -> Result<(), Error> {
         let test_target = human::test_with_color();
         let mut out = ::new().add_target(test_target.target());
+
         out.print(span().add_item("hello").fg("green")?.intense(true)?)?;
+        out.flush()?;
+
         assert_eq!(
             test_target.to_string(),
             "\u{1b}[0m\u{1b}[38;5;10mhello\u{1b}[0m\n"
@@ -182,7 +191,10 @@ mod test {
     fn test_underline_output() -> Result<(), Error> {
         let test_target = human::test_with_color();
         let mut out = ::new().add_target(test_target.target());
+
         out.print(span().add_item("hello").underline(true)?)?;
+        out.flush()?;
+
         assert_eq!(
             test_target.to_string(),
             "\u{1b}[0m\u{1b}[4mhello\u{1b}[0m\n"

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 use {human, json, Error, Render};
 
 /// Render some text
@@ -18,7 +17,7 @@ pub struct Text(String);
 
 impl Render for Text {
     fn render_for_humans(&self, fmt: &mut human::Formatter) -> Result<(), Error> {
-        fmt.writer.write_all(self.0.as_bytes())?;
+        fmt.write(self.0.as_bytes())?;
         Ok(())
     }
 

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -43,7 +43,7 @@ mod test {
 
             let json = json::test();
             item.render_json(&mut json.formatter()).unwrap();
-            prop_assert_eq!(json.to_string(), json!(s).to_string() + "\n");
+            prop_assert_eq!(json.to_string(), json!(s).to_string());
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
     /// Error dealing with JSON
     #[fail(display = "{}", _0)]
     Json(JsonError),
+    /// Error in formatting worker
+    #[fail(display = "{}", _0)]
+    WorkerError(String),
 }
 
 impl From<io::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,9 @@ pub enum Error {
     /// Error in formatting worker
     #[fail(display = "{}", _0)]
     WorkerError(String),
+    /// Error syncing output
+    #[fail(display = "Error syncing output")]
+    SyncError,
 }
 
 impl From<io::Error> for Error {

--- a/src/human.rs
+++ b/src/human.rs
@@ -1,20 +1,165 @@
 //! Human output
 
-use termcolor::{ColorChoice, StandardStream, WriteColor};
+use std::sync::Arc;
+use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
 use {Error, Target};
 
 /// Construct a new human output target that writes to stdout
 pub fn stdout() -> Result<Target, Error> {
-    Ok(Target::Human(Formatter {
-        writer: Box::new(StandardStream::stdout(ColorChoice::Auto)),
-    }))
+    Ok(Target::Human(Formatter::init_with(|| {
+        Ok(StandardStream::stdout(ColorChoice::Auto))
+    })?))
 }
 
 pub use self::test_helper::{test, test_with_color};
 
 /// Human output formatter
+#[derive(Clone)]
 pub struct Formatter {
-    pub(crate) writer: Box<dyn WriteColor>,
+    inner: Arc<InternalFormatter>,
+}
+
+impl Formatter {
+    pub(crate) fn init_with<W: WriteColor, F: FnOnce() -> Result<W, Error> + Send + 'static>(
+        init: F,
+    ) -> Result<Self, Error> {
+        Ok(Formatter {
+            inner: Arc::new(InternalFormatter::init_with(init)?),
+        })
+    }
+
+    /// Write to target
+    pub fn write<D: Into<Vec<u8>>>(&self, data: D) -> Result<(), Error> {
+        self.send(Message::Write(data.into()));
+        Ok(())
+    }
+
+    /// Set color
+    pub fn set_color(&self, spec: &ColorSpec) -> Result<(), Error> {
+        self.send(Message::SetColor(spec.clone()));
+        Ok(())
+    }
+
+    /// Reset color and styling
+    pub fn reset(&self) -> Result<(), Error> {
+        self.send(Message::ResetStyle);
+        Ok(())
+    }
+
+    /// Immediately write all buffered output
+    pub fn flush(&self) -> Result<(), Error> {
+        self.send(Message::Flush);
+
+        match self.inner.receiver.recv() {
+            Some(Response::Flushed) => Ok(()),
+            msg => Err(Error::WorkerError(format!("unexpected message {:?}", msg))),
+        }
+    }
+
+    fn send(&self, msg: Message) {
+        self.inner.sender.send(msg);
+    }
+}
+
+use crossbeam_channel as channel;
+use std::thread;
+
+struct InternalFormatter {
+    sender: channel::Sender<Message>,
+    receiver: channel::Receiver<Response>,
+    // Only an option so we can `take` this in `Drop::drop`
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl InternalFormatter {
+    pub(crate) fn init_with<W: WriteColor, F: FnOnce() -> Result<W, Error> + Send + 'static>(
+        init: F,
+    ) -> Result<Self, Error> {
+        let (message_sender, message_receiver) = channel::unbounded();
+        let (response_sender, response_receiver) = channel::bounded(0);
+
+        let worker = thread::spawn(move || {
+            let mut buffer = match init() {
+                Ok(buf) => {
+                    response_sender.send(Response::StartedSuccessfully);
+                    buf
+                }
+                Err(e) => {
+                    response_sender.send(Response::Error(e));
+                    return;
+                }
+            };
+
+            macro_rules! maybe_log_error {
+                () => {
+                    |e| {
+                        if cfg!(debug_assertions) {
+                            eprintln!("{}", e)
+                        } else {
+                            ()
+                        }
+                    }
+                };
+            }
+
+            loop {
+                match message_receiver.recv() {
+                    Some(Message::Write(data)) => {
+                        let _ = buffer.write_all(&data).map_err(maybe_log_error!());
+                    }
+                    Some(Message::SetColor(data)) => {
+                        let _ = buffer.set_color(&data).map_err(maybe_log_error!());
+                    }
+                    Some(Message::ResetStyle) => {
+                        let _ = buffer.reset().map_err(maybe_log_error!());
+                    }
+                    Some(Message::Flush) => {
+                        let _ = buffer.flush().map_err(maybe_log_error!());
+                        response_sender.send(Response::Flushed);
+                    }
+                    Some(Message::Exit) | None => {
+                        break;
+                    }
+                };
+            }
+        });
+
+        match response_receiver.recv() {
+            Some(Response::Error(error)) => Err(error),
+            Some(Response::StartedSuccessfully) => Ok(InternalFormatter {
+                worker: Some(worker),
+                sender: message_sender,
+                receiver: response_receiver,
+            }),
+            msg => Err(Error::WorkerError(format!("unexpected message {:?}", msg))),
+        }
+    }
+}
+
+impl Drop for InternalFormatter {
+    fn drop(&mut self) {
+        self.sender.send(Message::Exit);
+        // TODO: Docs say this may panic, so have a look at how to deal with that.
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Message {
+    Write(Vec<u8>),
+    SetColor(ColorSpec),
+    ResetStyle,
+    Flush,
+    Exit,
+}
+
+#[derive(Debug)]
+enum Response {
+    StartedSuccessfully,
+    Error(Error),
+    Flushed,
 }
 
 /// Shorthand for writing the `render_for_humans` method of the `Render`  trait
@@ -91,6 +236,7 @@ mod test_helper {
     ///     let test_target = output::human::test();
     ///     let mut out = output::new().add_target(test_target.target());
     ///     out.print(output::components::text("lorem ipsum"))?;
+    ///     out.flush()?;
     ///
     ///     assert_eq!(test_target.to_string(), "lorem ipsum\n");
     ///     Ok(())
@@ -117,9 +263,8 @@ mod test_helper {
 
     impl TestTarget {
         pub fn formatter(&self) -> Formatter {
-            Formatter {
-                writer: Box::new(self.buffer.clone()),
-            }
+            let buffer = self.buffer.clone();
+            Formatter::init_with(|| Ok(buffer)).unwrap()
         }
 
         pub fn target(&self) -> Target {

--- a/src/human.rs
+++ b/src/human.rs
@@ -1,14 +1,14 @@
 //! Human output
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
 use {Error, Target};
 
 /// Construct a new human output target that writes to stdout
 pub fn stdout() -> Result<Target, Error> {
-    Ok(Target::Human(Formatter::init_with(|| {
-        Ok(StandardStream::stdout(ColorChoice::Auto))
-    })?))
+    Ok(Target::Human(Arc::new(Mutex::new(Formatter::init_with(
+        || Ok(StandardStream::stdout(ColorChoice::Auto)),
+    )?))))
 }
 
 pub use self::test_helper::{test, test_with_color};
@@ -216,6 +216,7 @@ macro_rules! render_for_humans {
 
 mod test_helper {
     use super::Formatter;
+    use std::sync::{Arc, Mutex};
     use termcolor::Buffer;
     use {test_buffer::TestBuffer, Target};
 
@@ -268,7 +269,7 @@ mod test_helper {
         }
 
         pub fn target(&self) -> Target {
-            Target::Human(self.formatter())
+            Target::Human(Arc::new(Mutex::new(self.formatter())))
         }
 
         pub fn to_string(&self) -> String {

--- a/src/json.rs
+++ b/src/json.rs
@@ -242,7 +242,7 @@ mod test_helper {
     ///
     ///     assert_eq!(
     ///         test_target.to_string(),
-    ///         "{\"author\":\"Pascal\",\"body\":\"Lorem ipsum dolor\"}\n\n",
+    ///         "{\"author\":\"Pascal\",\"body\":\"Lorem ipsum dolor\"}\n",
     ///     );
     ///     Ok(())
     /// }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,46 +1,168 @@
 //! JSON output
 
 use serde::Serialize;
-use serde_json::to_writer as write_json;
+use serde_json::to_vec as write_json;
 use std::io::Write;
 use std::path::Path;
+use std::sync::Arc;
 use {Error, Target};
 
 /// Create a new JSON output that writes to a file
 pub fn file<T: AsRef<Path>>(name: T) -> Result<Target, Error> {
-    use std::fs::{File, OpenOptions};
-    use std::io::BufWriter;
+    let path = name.as_ref().to_path_buf();
+    Ok(Target::Json(Formatter::init_with(move || {
+        use std::fs::{File, OpenOptions};
+        use std::io::BufWriter;
 
-    let target = if name.as_ref().exists() {
-        let mut f = OpenOptions::new().write(true).append(true).open(name)?;
-        f.write_all(b"\n")?;
+        let target = if path.exists() {
+            let mut f = OpenOptions::new().write(true).append(true).open(&path)?;
+            f.write_all(b"\n")?;
 
-        f
-    } else {
-        File::create(name)?
-    };
+            f
+        } else {
+            File::create(&path)?
+        };
 
-    let t = BufWriter::new(target);
-
-    Ok(Target::Json(Formatter {
-        writer: Box::new(t),
-    }))
+        Ok(BufWriter::new(target))
+    })?))
 }
 
 pub use self::test_helper::test;
 
 /// JSON formatter
 pub struct Formatter {
-    pub(crate) writer: Box<Write>,
+    inner: Arc<InternalFormatter>,
 }
 
 impl Formatter {
+    pub(crate) fn init_with<W: Write, F: FnOnce() -> Result<W, Error> + Send + 'static>(
+        init: F,
+    ) -> Result<Self, Error> {
+        Ok(Formatter {
+            inner: Arc::new(InternalFormatter::init_with(init)?),
+        })
+    }
+
     /// Write a serializable item to the JSON formatter
-    pub fn write<T: Serialize>(&mut self, item: &T) -> Result<(), Error> {
-        write_json(&mut self.writer, item)?;
-        self.writer.write_all(b"\n")?;
+    pub fn write<T: Serialize>(&self, item: &T) -> Result<(), Error> {
+        let mut bytes = write_json(item)?;
+        bytes.push(b'\n');
+        self.send(Message::Write(bytes));
         Ok(())
     }
+
+    /// Immediately write all buffered output
+    pub fn flush(&self) -> Result<(), Error> {
+        self.send(Message::Flush);
+
+        match self.inner.receiver.recv() {
+            Some(Response::Flushed) => Ok(()),
+            msg => Err(Error::WorkerError(format!("unexpected message {:?}", msg))),
+        }
+    }
+
+    /// Write a separator after a record
+    pub(crate) fn write_separator(&mut self) -> Result<(), Error> {
+        self.send(Message::Write(vec![b'\n']));
+        Ok(())
+    }
+
+    fn send(&self, msg: Message) {
+        self.inner.sender.send(msg);
+    }
+}
+
+use crossbeam_channel as channel;
+use std::thread;
+
+struct InternalFormatter {
+    sender: channel::Sender<Message>,
+    receiver: channel::Receiver<Response>,
+    // Only an option so we can `take` this in `Drop::drop`
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl InternalFormatter {
+    pub(crate) fn init_with<W: Write, F: FnOnce() -> Result<W, Error> + Send + 'static>(
+        init: F,
+    ) -> Result<Self, Error> {
+        let (message_sender, message_receiver) = channel::unbounded();
+        let (response_sender, response_receiver) = channel::bounded(0);
+
+        let worker = thread::spawn(move || {
+            let mut buffer = match init() {
+                Ok(buf) => {
+                    response_sender.send(Response::StartedSuccessfully);
+                    buf
+                }
+                Err(e) => {
+                    response_sender.send(Response::Error(e));
+                    return;
+                }
+            };
+
+            macro_rules! maybe_log_error {
+                () => {
+                    |e| {
+                        if cfg!(debug_assertions) {
+                            eprintln!("{}", e)
+                        } else {
+                            ()
+                        }
+                    }
+                };
+            }
+
+            loop {
+                match message_receiver.recv() {
+                    Some(Message::Write(data)) => {
+                        let _ = buffer.write_all(&data).map_err(maybe_log_error!());
+                    }
+                    Some(Message::Flush) => {
+                        let _ = buffer.flush().map_err(maybe_log_error!());
+                        response_sender.send(Response::Flushed);
+                    }
+                    Some(Message::Exit) | None => {
+                        break;
+                    }
+                };
+            }
+        });
+
+        match response_receiver.recv() {
+            Some(Response::Error(error)) => Err(error),
+            Some(Response::StartedSuccessfully) => Ok(InternalFormatter {
+                worker: Some(worker),
+                sender: message_sender,
+                receiver: response_receiver,
+            }),
+            msg => Err(Error::WorkerError(format!("unexpected message {:?}", msg))),
+        }
+    }
+}
+
+impl Drop for InternalFormatter {
+    fn drop(&mut self) {
+        self.sender.send(Message::Exit);
+        // TODO: Docs say this may panic, so have a look at how to deal with that.
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Message {
+    Write(Vec<u8>),
+    Flush,
+    Exit,
+}
+
+#[derive(Debug)]
+enum Response {
+    StartedSuccessfully,
+    Error(Error),
+    Flushed,
 }
 
 /// Shorthand for writing the `render_json` method of the `Render`  trait
@@ -114,6 +236,7 @@ mod test_helper {
     ///     }
     ///
     ///     out.print(Message { author: "Pascal".into(), body: "Lorem ipsum dolor".into() })?;
+    ///     out.flush()?;
     ///
     ///     assert_eq!(
     ///         test_target.to_string(),
@@ -134,9 +257,8 @@ mod test_helper {
 
     impl TestTarget {
         pub fn formatter(&self) -> Formatter {
-            Formatter {
-                writer: Box::new(self.buffer.clone()),
-            }
+            let buffer = self.buffer.clone();
+            Formatter::init_with(|| Ok(buffer)).unwrap()
         }
 
         pub fn target(&self) -> Target {
@@ -207,12 +329,10 @@ mod tests {
         log_file.write_str(intitial_content)?;
         log_file.assert(predicate::path::exists());
 
-        {
-            // drop to flush file write buffer
-            let target = json::file(log_file.path())?;
-            let mut output = ::new().add_target(target);
-            output.print("wtf")?;
-        }
+        let target = json::file(log_file.path())?;
+        let mut output = ::new().add_target(target);
+        output.print("wtf")?;
+        output.flush()?;
 
         log_file.assert(
             predicate::str::ends_with("\"wtf\"")


### PR DESCRIPTION
Human and JSON targets now spawn a thread that will do all the stuff.
This mean we now have to pass in an initializer closure so buffers don't
have to be send.

Oh, and since we are dealing with threads, I've also had the pleasure of
adding some channels here and there. We have one unbounded channel that
takes all write requests. We keep the sender of that one, and pass the
receiver to the thread. To get stuff out of the thread, we have another
channel. This one is more synchronous by having a capacity of 0 -- IIRC
that means it'll block until we have received its content. Of this
"response channel", we pass the sender into the thread and keep a single
receiver for ourselves.

While initializing the formatter, this is also the channel we block on
to see if the thread started successfully or if there was an error.
Because, yes, our initializer can return an error.

Along the way, I've also added a `flush` method, so that we can now in
tests just call that instead of dropping the output explicitly as a sync
point. (This too is synchronized using the response channel).